### PR TITLE
Load keyboard layout from JSON scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,13 +138,8 @@ body {
   padding: clamp(10px, 2vw, 30px);
   box-shadow: inset 0 0 0 2px rgba(0,0,0,0.8);
   display: grid;
-  grid-template-rows: repeat(5, 1fr);
-  gap: clamp(6px, 1vw, 14px);
-}
-
-.key-row {
-  display: grid;
   grid-template-columns: repeat(10, 1fr);
+  grid-template-rows: repeat(5, minmax(clamp(34px, 4.6vw, 64px), auto));
   gap: clamp(6px, 1vw, 14px);
 }
 
@@ -190,7 +185,6 @@ button.key:active {
   position: absolute;
   left: 10%;
   right: 10%;
-  font-size: clamp(7px, 0.8vw, 11px);
   font-weight: 500;
   letter-spacing: 0.08em;
   pointer-events: none;
@@ -199,12 +193,14 @@ button.key:active {
 
 .key .legend-f {
   top: 10%;
+  font-size: clamp(8px, 0.9vw, 12px);
   color: var(--hp-orange);
   text-align: left;
 }
 
 .key .legend-g {
   bottom: 12%;
+  font-size: clamp(6px, 0.7vw, 9px);
   color: var(--hp-blue);
   text-align: right;
 }
@@ -282,355 +278,19 @@ footer.signature {
   <footer class="signature">HP 12C • Platinum Edition</footer>
 </div>
 <script>
-const KEY_LAYOUT = [
-  {
-    position: '1,1',
-    color: 'black',
-    mainFunction: 'n',
-    f_secondaryFunction: '12x',
-    g_secondaryFunction: 'BOND',
-    isEnterKey: false
-  },
-  {
-    position: '1,2',
-    color: 'black',
-    mainFunction: 'i',
-    f_secondaryFunction: '12÷',
-    g_secondaryFunction: 'PRICE',
-    isEnterKey: false
-  },
-  {
-    position: '1,3',
-    color: 'black',
-    mainFunction: 'PV',
-    f_secondaryFunction: 'CFo',
-    g_secondaryFunction: 'YTM',
-    isEnterKey: false
-  },
-  {
-    position: '1,4',
-    color: 'black',
-    mainFunction: 'PMT',
-    f_secondaryFunction: 'CFj',
-    g_secondaryFunction: 'SL',
-    isEnterKey: false
-  },
-  {
-    position: '1,5',
-    color: 'black',
-    mainFunction: 'FV',
-    f_secondaryFunction: 'Nj',
-    g_secondaryFunction: 'SOYD',
-    isEnterKey: false
-  },
-  {
-    position: '1,6',
-    color: 'black',
-    mainFunction: 'RND',
-    f_secondaryFunction: null,
-    g_secondaryFunction: 'DB',
-    isEnterKey: false
-  },
-  {
-    position: '1,7',
-    color: 'black',
-    mainFunction: 'IRR',
-    f_secondaryFunction: 'RPN',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '1,8',
-    color: 'black',
-    mainFunction: 'CHS',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '1,9',
-    color: 'black',
-    mainFunction: 'DATE',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '2,1',
-    color: 'black',
-    mainFunction: 'yx',
-    f_secondaryFunction: 'x√',
-    g_secondaryFunction: 'PRGM',
-    isEnterKey: false
-  },
-  {
-    position: '2,2',
-    color: 'black',
-    mainFunction: '1/x',
-    f_secondaryFunction: 'e^x',
-    g_secondaryFunction: 'REG',
-    isEnterKey: false
-  },
-  {
-    position: '2,3',
-    color: 'black',
-    mainFunction: '%T',
-    f_secondaryFunction: 'LN',
-    g_secondaryFunction: 'CLEAR FIN',
-    isEnterKey: false
-  },
-  {
-    position: '2,4',
-    color: 'black',
-    mainFunction: '∆%',
-    f_secondaryFunction: 'frac',
-    g_secondaryFunction: 'Σ',
-    isEnterKey: false
-  },
-  {
-    position: '2,5',
-    color: 'black',
-    mainFunction: '%',
-    f_secondaryFunction: 'intg',
-    g_secondaryFunction: 'Σ+',
-    isEnterKey: false
-  },
-  {
-    position: '2,6',
-    color: 'black',
-    mainFunction: 'EEX',
-    f_secondaryFunction: null,
-    g_secondaryFunction: 'ADYS',
-    isEnterKey: false
-  },
-  {
-    position: '2,7',
-    color: 'black',
-    mainFunction: '4',
-    f_secondaryFunction: 'M.DY',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '2,8',
-    color: 'black',
-    mainFunction: '5',
-    f_secondaryFunction: 'D.MY',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '2,9',
-    color: 'black',
-    mainFunction: '6',
-    f_secondaryFunction: 'D.M',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '2,10',
-    color: 'black',
-    mainFunction: 'x',
-    f_secondaryFunction: 'x̅,r',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '3,1',
-    color: 'black',
-    mainFunction: 'R/S',
-    f_secondaryFunction: 'P/R',
-    g_secondaryFunction: 'PSE',
-    isEnterKey: false
-  },
-  {
-    position: '3,2',
-    color: 'black',
-    mainFunction: 'SST',
-    f_secondaryFunction: 'BST',
-    g_secondaryFunction: 'GTO',
-    isEnterKey: false
-  },
-  {
-    position: '3,3',
-    color: 'black',
-    mainFunction: 'R↓',
-    f_secondaryFunction: 'RST',
-    g_secondaryFunction: 'Σ',
-    isEnterKey: false
-  },
-  {
-    position: '3,4',
-    color: 'black',
-    mainFunction: 'x<>y',
-    f_secondaryFunction: 'x=0',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '3,5',
-    color: 'black',
-    mainFunction: 'CLx',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '3,6',
-    color: 'black',
-    mainFunction: '7',
-    f_secondaryFunction: 'BEG',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '3,7',
-    color: 'black',
-    mainFunction: '8',
-    f_secondaryFunction: 'END',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '3,8',
-    color: 'black',
-    mainFunction: '9',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '3,9',
-    color: 'black',
-    mainFunction: '÷',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '4,1',
-    color: 'orange',
-    mainFunction: 'f',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '4,2',
-    color: 'blue',
-    mainFunction: 'g',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '4,3',
-    color: 'black',
-    mainFunction: 'STO',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '4,4',
-    color: 'black',
-    mainFunction: 'RCL',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '4,5',
-    color: 'black',
-    mainFunction: 'ENTER',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: true
-  },
-  {
-    position: '4,6',
-    color: 'black',
-    mainFunction: '1',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '4,7',
-    color: 'black',
-    mainFunction: '2',
-    f_secondaryFunction: 'Σ-',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '4,8',
-    color: 'black',
-    mainFunction: '3',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '4,9',
-    color: 'black',
-    mainFunction: '-',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '5,1',
-    color: 'black',
-    mainFunction: 'ON',
-    f_secondaryFunction: 'OFF',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '5,2',
-    color: 'black',
-    mainFunction: '0',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '5,3',
-    color: 'black',
-    mainFunction: '.',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '5,4',
-    color: 'black',
-    mainFunction: 'Σ+',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '5,5',
-    color: 'black',
-    mainFunction: '∑',
-    f_secondaryFunction: '∑-',
-    g_secondaryFunction: null,
-    isEnterKey: false
-  },
-  {
-    position: '5,6',
-    color: 'black',
-    mainFunction: '+',
-    f_secondaryFunction: null,
-    g_secondaryFunction: null,
-    isEnterKey: false
+const KEYBOARD_SCHEME_URL = 'keyboard-scheme.json';
+
+async function loadKeyboardLayout() {
+  const response = await fetch(KEYBOARD_SCHEME_URL);
+  if (!response.ok) {
+    throw new Error(`Não foi possível carregar o arquivo ${KEYBOARD_SCHEME_URL}`);
   }
-];
+  return response.json();
+}
+
 
 const DISPLAY_OVERRIDES = {
-  yx: 'yˣ',
+  'yˆx': 'yˣ',
   x: '×',
   '-': '−',
   'x<>y': 'x↔y'
@@ -646,7 +306,7 @@ const ACTION_OVERRIDES = {
   IRR: 'irr',
   CHS: 'chs',
   DATE: 'date',
-  yx: 'power',
+  'yˆx': 'power',
   '1/x': 'reciprocal',
   '%T': 'percent-total',
   '∆%': 'delta-percent',
@@ -718,26 +378,56 @@ function createKeyElement(key) {
   return button;
 }
 
-function buildKeypadLayout(container) {
+function parsePosition(position) {
+  const [row, column] = position.split(',').map(Number);
+  return { row, column };
+}
+
+function buildKeypadLayout(container, layout) {
   container.innerHTML = '';
-  const layoutMap = new Map(KEY_LAYOUT.map((key) => [key.position, key]));
+  const occupied = new Set();
+  const sortedLayout = [...layout].sort((a, b) => {
+    const posA = parsePosition(a.position);
+    const posB = parsePosition(b.position);
+    if (posA.row === posB.row) {
+      return posA.column - posB.column;
+    }
+    return posA.row - posB.row;
+  });
 
-  for (let row = 1; row <= ROW_COUNT; row++) {
-    const rowEl = document.createElement('div');
-    rowEl.classList.add('key-row');
-
-    for (let col = 1; col <= COLUMN_COUNT; col++) {
-      const key = layoutMap.get(`${row},${col}`);
-      if (key) {
-        rowEl.appendChild(createKeyElement(key));
-      } else {
-        const placeholder = document.createElement('div');
-        placeholder.classList.add('key', 'key-empty');
-        rowEl.appendChild(placeholder);
-      }
+  sortedLayout.forEach((key) => {
+    if (occupied.has(key.position)) {
+      return;
     }
 
-    container.appendChild(rowEl);
+    const element = createKeyElement(key);
+    const { row, column } = parsePosition(key.position);
+
+    element.style.gridRowStart = row;
+    element.style.gridColumnStart = column;
+
+    if (key.isEnterKey) {
+      element.style.gridRowEnd = 'span 2';
+      occupied.add(`${row + 1},${column}`);
+    }
+
+    occupied.add(key.position);
+    container.appendChild(element);
+  });
+
+  for (let row = 1; row <= ROW_COUNT; row++) {
+    for (let column = 1; column <= COLUMN_COUNT; column++) {
+      const position = `${row},${column}`;
+      if (occupied.has(position)) {
+        continue;
+      }
+      const placeholder = document.createElement('div');
+      placeholder.classList.add('key', 'key-empty');
+      placeholder.style.gridRowStart = row;
+      placeholder.style.gridColumnStart = column;
+      container.appendChild(placeholder);
+      occupied.add(position);
+    }
   }
 }
 
@@ -1124,99 +814,111 @@ const numberMap = {
 
 const keypad = document.querySelector('.keypad');
 
-if (keypad) {
-  buildKeypadLayout(keypad);
+function onKeypadClick(event) {
+  const button = event.target.closest('button');
+  if (!button) return;
 
-  keypad.addEventListener('click', (event) => {
-    const button = event.target.closest('button');
-    if (!button) return;
+  const action = button.dataset.action;
+  if (!action) return;
 
-    const action = button.dataset.action;
-    if (!action) return;
-
-    if (action in numberMap) {
-      const digit = numberMap[action];
-      if (digit === '00') {
-        calculator.inputDigit('0');
-        calculator.inputDigit('0');
-      } else {
-        calculator.inputDigit(digit);
-      }
-      return;
+  if (action in numberMap) {
+    const digit = numberMap[action];
+    if (digit === '00') {
+      calculator.inputDigit('0');
+      calculator.inputDigit('0');
+    } else {
+      calculator.inputDigit(digit);
     }
+    return;
+  }
 
-    switch (action) {
-      case 'decimal':
-        calculator.inputDigit('.');
-        break;
-      case 'chs':
-        calculator.toggleSign();
-        break;
-      case 'enter':
-        calculator.enter();
-        break;
-      case 'plus':
-        calculator.performOperation('+');
-        break;
-      case 'minus':
-        calculator.performOperation('-');
-        break;
-      case 'mul':
-        calculator.performOperation('*');
-        break;
-      case 'div':
-        calculator.performOperation('/');
-        break;
-      case 'clx':
-        calculator.clearX();
-        break;
-      case 'xchg':
-        calculator.swapXY();
-        break;
-      case 'lastx':
-        calculator.recallLastX();
-        break;
-      case 'rdown':
-        calculator.stackRollDown();
-        break;
-      case 'mem-clear':
-        calculator.clearRegisters();
-        break;
-      case 'sto':
-        calculator.stoPending = true;
-        calculator.rclPending = false;
-        calculator.updateStatus();
-        break;
-      case 'rcl':
-        calculator.rclPending = true;
-        calculator.stoPending = false;
-        calculator.updateStatus();
-        break;
-      case 'mem-plus':
-        calculator.stoPending = false;
-        calculator.rclPending = false;
-        calculator.memoryPlus(0);
-        calculator.updateStatus();
-        break;
-      case 'mem-minus':
-        calculator.stoPending = false;
-        calculator.rclPending = false;
-        calculator.memoryMinus(0);
-        calculator.updateStatus();
-        break;
-      case 'pmt':
-      case 'pv':
-      case 'fv':
-      case 'n':
-      case 'i':
-        handleTVM(action);
-        break;
-      default:
-        handleSpecial(action);
-        break;
-    }
-  });
+  switch (action) {
+    case 'decimal':
+      calculator.inputDigit('.');
+      break;
+    case 'chs':
+      calculator.toggleSign();
+      break;
+    case 'enter':
+      calculator.enter();
+      break;
+    case 'plus':
+      calculator.performOperation('+');
+      break;
+    case 'minus':
+      calculator.performOperation('-');
+      break;
+    case 'mul':
+      calculator.performOperation('*');
+      break;
+    case 'div':
+      calculator.performOperation('/');
+      break;
+    case 'clx':
+      calculator.clearX();
+      break;
+    case 'xchg':
+      calculator.swapXY();
+      break;
+    case 'lastx':
+      calculator.recallLastX();
+      break;
+    case 'rdown':
+      calculator.stackRollDown();
+      break;
+    case 'mem-clear':
+      calculator.clearRegisters();
+      break;
+    case 'sto':
+      calculator.stoPending = true;
+      calculator.rclPending = false;
+      calculator.updateStatus();
+      break;
+    case 'rcl':
+      calculator.rclPending = true;
+      calculator.stoPending = false;
+      calculator.updateStatus();
+      break;
+    case 'mem-plus':
+      calculator.stoPending = false;
+      calculator.rclPending = false;
+      calculator.memoryPlus(0);
+      calculator.updateStatus();
+      break;
+    case 'mem-minus':
+      calculator.stoPending = false;
+      calculator.rclPending = false;
+      calculator.memoryMinus(0);
+      calculator.updateStatus();
+      break;
+    case 'pmt':
+    case 'pv':
+    case 'fv':
+    case 'n':
+    case 'i':
+      handleTVM(action);
+      break;
+    default:
+      handleSpecial(action);
+      break;
+  }
 }
+
+async function initializeKeypad() {
+  if (!keypad) {
+    return;
+  }
+
+  try {
+    const layout = await loadKeyboardLayout();
+    buildKeypadLayout(keypad, layout);
+    keypad.addEventListener('click', onKeypadClick);
+  } catch (error) {
+    console.error('Erro ao inicializar o teclado virtual.', error);
+  }
+}
+
+initializeKeypad();
 
 function handleTVM(key) {
   const keyMap = { n: 'n', i: 'i', pv: 'pv', pmt: 'pmt', fv: 'fv' };


### PR DESCRIPTION
## Summary
- load the keyboard layout dynamically from `keyboard-scheme.json` and build the grid so the ENTER key spans two rows
- adjust keypad styling to work as a single grid and style f/g legends with the requested color/size treatment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5a248f4ac8326adf449348489ea4a