### PR TITLE
Preserve stack top after calculations

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,6 +447,8 @@ class HP12C {
     this.decimalEntered = false;
     this.stoPending = false;
     this.rclPending = false;
+    this.preserveTopOnNextEntry = false;
+    this.skipNextEnterDuplicate = false;
     this.memoryRegisters = new Array(20).fill(0);
     this.tvm = {
       n: 0,
@@ -510,17 +512,30 @@ class HP12C {
   }
 
   enter() {
+    const shouldSkipDuplicate = this.entryActive && this.skipNextEnterDuplicate;
     this.commitEntry();
     this.stack[3] = this.stack[2];
     this.stack[2] = this.stack[1];
-    this.stack[1] = this.stack[0];
+    if (!shouldSkipDuplicate) {
+      this.stack[1] = this.stack[0];
+    }
     this.entryActive = false;
     this.decimalEntered = false;
+    this.skipNextEnterDuplicate = false;
     this.updateDisplay();
   }
 
   inputDigit(digit) {
     if (!this.entryActive) {
+      if (this.preserveTopOnNextEntry) {
+        this.stack[3] = this.stack[2];
+        this.stack[2] = this.stack[1];
+        this.stack[1] = this.stack[0];
+        this.preserveTopOnNextEntry = false;
+        this.skipNextEnterDuplicate = true;
+      } else {
+        this.skipNextEnterDuplicate = false;
+      }
       this.entryBuffer = '';
       this.entryActive = true;
     }
@@ -546,6 +561,7 @@ class HP12C {
   }
 
   performOperation(op) {
+    this.skipNextEnterDuplicate = false;
     this.commitEntry();
     const x = this.stack[0];
     const y = this.stack[1];
@@ -586,6 +602,7 @@ class HP12C {
       default:
         return;
     }
+    this.preserveTopOnNextEntry = true;
     this.updateDisplay();
   }
 
@@ -676,6 +693,8 @@ class HP12C {
     try {
       const result = this.solveTVM(target);
       this.stack[0] = result;
+      this.preserveTopOnNextEntry = true;
+      this.skipNextEnterDuplicate = false;
       this.updateDisplay();
     } catch (error) {
       this.displayError('Error');


### PR DESCRIPTION
## Summary
- retain calculation results by deferring stack replacement when the next numeric entry begins
- add state tracking so ENTER can optionally avoid duplicating the latest entry and keep the prior result accessible
- ensure arithmetic and TVM computations flag the stack for preservation after producing a result

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5a6d093e08326b5161036b00047a4